### PR TITLE
Add a queue monitor

### DIFF
--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -47,7 +47,7 @@ def test_send_records(producer, client, n):
 
 
 @mock_kinesis
-@pytest.mark.parametrize('n', [1, 101, 179, 234, 399])
+@pytest.mark.parametrize('n', [49, 141])
 def test_send_records_without_close(producer, client, n):
     client.create_stream(StreamName=producer.stream_name, ShardCount=1)
 
@@ -55,7 +55,7 @@ def test_send_records_without_close(producer, client, n):
     for i in range(n):
         producer.put_record(i)
 
-    time.sleep(2)
+    time.sleep(1.5)
 
     assert producer.queue.empty()
 

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -55,8 +55,19 @@ def test_send_records_without_close(producer, client, n):
     for i in range(n):
         producer.put_record(i)
 
-    time.sleep(1.5)
+    time.sleep(2)
 
     assert producer.queue.empty()
 
     producer.close()
+
+    response = client.describe_stream(StreamName=producer.stream_name)
+    shard_id = response['StreamDescription']['Shards'][0]['ShardId']
+    shard_iterator = client.get_shard_iterator(
+        StreamName=producer.stream_name,
+        ShardId=shard_id,
+        ShardIteratorType='TRIM_HORIZON'
+    ).get('ShardIterator')
+
+    records = client.get_records(ShardIterator=shard_iterator, Limit=n)['Records']
+    assert len(records) == n


### PR DESCRIPTION
This PR adds the feature to set a timed flush in case the producer is not constantly sending records.

Closes https://github.com/bufferapp/kiner/issues/1