### PR TITLE
Avoid continuously checking if it's time to flush the queue

### DIFF
--- a/kiner/producer.py
+++ b/kiner/producer.py
@@ -65,7 +65,7 @@ class KinesisProducer:
                 if not self.queue.empty():
                     logger.info("Queue Flush: time without flush exceeded")
                     self.flush_queue()
-                    time.sleep(self.batch_time)
+            time.sleep(self.batch_time)
 
     def put_records(self, records, partition_key=None):
         """Add a list of data records to the record queue in the proper format.


### PR DESCRIPTION
In the current state, the monitor thread used 100% of one CPU, since it's always checking if it should flush (it only waits for batch_time if it just flushed the queue). Just create an instance of KinesisProducer, do a time.sleep(1000) and check the cpu usage.