### PR TITLE
Remove logging of record data

### DIFF
--- a/kiner/producer.py
+++ b/kiner/producer.py
@@ -112,7 +112,7 @@ class KinesisProducer:
             self.pool.submit(self.flush_queue)
 
         # Append the record
-        logger.info('Putting record "{}"'.format(record['Data'][:100]))
+        logger.debug('Putting record "{}"'.format(record['Data'][:100]))
         self.queue.put(record)
 
     def close(self):

--- a/kiner/producer.py
+++ b/kiner/producer.py
@@ -112,6 +112,7 @@ class KinesisProducer:
             self.pool.submit(self.flush_queue)
 
         # Append the record
+        logger.info('Putting record "{}"'.format(record['Data'][:100]))
         self.queue.put(record)
 
     def close(self):

--- a/kiner/producer.py
+++ b/kiner/producer.py
@@ -112,7 +112,6 @@ class KinesisProducer:
             self.pool.submit(self.flush_queue)
 
         # Append the record
-        logger.info('Putting record "{}"'.format(record['Data'][:100]))
         self.queue.put(record)
 
     def close(self):


### PR DESCRIPTION
Hi @davidgasquez!

Just a small change I would love to run by you. As we're auditing which data we log for GDPR I noticed that we're logging record data for each record added to the producer. Since these records could potentially contain personal data, I was thinking that perhaps we could remove this logging?