### PR TITLE
Remove boto3 instantiation from constructor definition

### DIFF
--- a/kiner/producer.py
+++ b/kiner/producer.py
@@ -43,12 +43,14 @@ class KinesisProducer:
 
     def __init__(self, stream_name, batch_size=500,
                  batch_time=5, max_retries=5, threads=10,
-                 kinesis_client=boto3.client('kinesis')):
+                 kinesis_client=None):
         self.stream_name = stream_name
         self.queue = Queue()
         self.batch_size = batch_size
         self.batch_time = batch_time
         self.max_retries = max_retries
+        if kinesis_client is None:
+            kinesis_client = boto3.client('kinesis')
         self.kinesis_client = kinesis_client
         self.pool = ThreadPoolExecutor(threads)
         self.last_flush = time.time()


### PR DESCRIPTION
We noticed that boto3 client was instantiated as soon as KinesisProducer class was imported, even before instantiating KinesisProducer itself.

When using a custom boto3 class, this means that two boto3 instantiations would happen (one at kiner import, one custom), causing slower script startup times.

The cause is giving `kinesis_client` parameter a default value of `boto3.client('kinesis')` in the constructor definition.

As per Python documentation:
```
Default parameter values are evaluated when the function definition is executed. This means that the expression is evaluated once, when the function is defined, and that that same ``pre-computed'' value is used for each call.
```

Submitting a quick fix that makes KinesisProducer class import super fast and only instantiates a default boto3 client only when necessary.