### PR TITLE
Add future package to ensure Python2 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,5 @@ setup(
     author_email='davidgasquez@buffer.com',
     url='https://github.com/bufferapp/kiner',
     keywords=['kinesis', 'producer', 'aws'],
-    install_requires=['boto3']
+    install_requires=['boto3', 'future']
 )


### PR DESCRIPTION
Hi @davidgasquez!

Just a small fix, I came across an issue on this line when trying to use `kiner` in Python2:

https://github.com/bufferapp/kiner/blob/master/kiner/producer.py#L4

It seems this was caused by importing from `queue` instead of `Queue` (http://python-future.org/compatible_idioms.html#queue)

The easy fix was just to use the `future` package, which could be great for potential other compatibility issues.