### PR TITLE
Update put_record docstring

### DIFF
--- a/kiner/producer.py
+++ b/kiner/producer.py
@@ -98,8 +98,10 @@ class KinesisProducer:
 
         Parameters
         ----------
-        data : str
+        data : str|bytes
             Data to send.
+        metadata: dict
+            Metadata associated with the record.
         partition_key: str
             Hash that determines which shard a given data record belongs to.
 


### PR DESCRIPTION
- Metadata field in `put_record` wasn't in the docstring.
- Data field can also be bytes as `encode_data` checks if bytes first